### PR TITLE
Don't respond to XML format for controllers

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,6 @@ class UsersController < ApplicationController
   load_and_authorize_resource
 
   # GET /users
-  # GET /users.xml
   def index
     if params[:q].nil?
       @users = User.all
@@ -11,22 +10,11 @@ class UsersController < ApplicationController
       # Recherche simple dans le trombi
       @users = User.search(params[:q])
     end
-
-    respond_to do |format|
-      format.html # index.html.erb
-      format.xml  { render :xml => @users }
-    end
   end
 
   # GET /users/1
-  # GET /users/1.xml
   def show
     @user = User.find(params[:id])
-
-    respond_to do |format|
-      format.html # show.html.erb
-      format.xml  { render :xml => @user }
-    end
   end
 
   def password_reset
@@ -56,14 +44,8 @@ class UsersController < ApplicationController
   end
 
   # GET /users/new
-  # GET /users/new.xml
   def new
     @user = User.new
-
-    respond_to do |format|
-      format.html # new.html.erb
-      format.xml  { render :xml => @user }
-    end
   end
 
   # GET /users/1/edit
@@ -72,47 +54,33 @@ class UsersController < ApplicationController
   end
 
   # POST /users
-  # POST /users.xml
   def create
     @user = User.new(params[:user])
 
-    respond_to do |format|
-      if @user.save
-        cookies[:auth_token] = @user.auth_token
-        format.html { redirect_to(:root, :notice => t('c.create')) }
-        format.xml  { render :xml => @user, :status => :created, :location => @user }
-      else
-        format.html { render :action => "new" }
-        format.xml  { render :xml => @user.errors, :status => :unprocessable_entity }
-      end
+    if @user.save
+      cookies[:auth_token] = @user.auth_token
+      redirect_to(:root, :notice => t('c.create'))
+    else
+      render :action => "new"
     end
   end
 
   # PUT /users/1
-  # PUT /users/1.xml
   def update
     @user = User.find(params[:id])
 
-    respond_to do |format|
-      if @user.update_attributes(params[:user])
-        format.html { redirect_to(@user, :notice => t('c.update')) }
-        format.xml  { head :ok }
-      else
-        format.html { render :action => "edit" }
-        format.xml  { render :xml => @user.errors, :status => :unprocessable_entity }
-      end
+    if @user.update_attributes(params[:user])
+      redirect_to(@user, :notice => t('c.update'))
+    else
+      render :action => "edit"
     end
   end
 
   # DELETE /users/1
-  # DELETE /users/1.xml
   def destroy
     @user = User.find(params[:id])
     @user.destroy
 
-    respond_to do |format|
-      format.html { redirect_to(users_url) }
-      format.xml  { head :ok }
-    end
+    redirect_to(users_url)
   end
 end


### PR DESCRIPTION
Je propose qu'on vire le support du XML dans les contrôleurs :
- ça complexifie énormément le code pour rien
- ça ne sera utilisé par personne
- ça fait du code non testé
- [troll]si on fait une API un jour, elle sera pas en XML mais en JSON[/troll]

Si t'es d'accord @Dorian, je ferais de même pour les autres contrôleurs puis merge dans master.
